### PR TITLE
feat: Including "isNotEmpty" extension property for any vavr Value such as Option

### DIFF
--- a/src/main/kotlin/io/vavr/kotlin/Control.kt
+++ b/src/main/kotlin/io/vavr/kotlin/Control.kt
@@ -20,6 +20,7 @@
 package io.vavr.kotlin
 
 import io.vavr.CheckedFunction0
+import io.vavr.Value
 import io.vavr.collection.Seq
 import io.vavr.control.Either
 import io.vavr.control.Option
@@ -73,6 +74,13 @@ fun <A> Boolean.option(a: () -> A):
 fun <T> Iterable<Option<T>>.sequence():
         Option<Seq<T>> = Option.sequence(this)
 
+/**
+ * Checks, this {@code Value} is not empty, i.e. if the underlying value
+ * is present.
+ *
+ * @return true, if underlying value is present, false otherwise.
+ */
+val <T> Value<T>.isNotEmpty get() = !this.isEmpty
 
 /**
  * @see Validation.invalid

--- a/src/test/kotlin/io/vavr/kotlin/ControlKtTest.kt
+++ b/src/test/kotlin/io/vavr/kotlin/ControlKtTest.kt
@@ -72,6 +72,15 @@ class ControlKtTest {
         assert(x3.get().size() == 2)
     }
 
+    @Test
+    fun optionIsNotEmpty() {
+        val first: Option<Int?> = some(4)
+        assert(first.isNotEmpty)
+
+        val second: Option<Int?> = none()
+        assert(!second.isNotEmpty)
+    }
+
     // -- Try
 
     @Test


### PR DESCRIPTION
Hi,

Using your library on one of my projects, so I include a Kotlin extension property into Option (https://kotlinlang.org/docs/reference/extensions.html) to improve legibility of code. In my opinion, is better to read ```foo.isNotEmpty``` than ```!foo.isEmpty```. So initially I use it for an Option but in this pull-request I include any Vavr Value type.

I'm not sure If you want to include it on your library but I want share with you this feature.

Best regards,
Jorge Aranda

